### PR TITLE
Fix: allow rendering only one pageItem

### DIFF
--- a/__tests__/PaginationBoxView-test.js
+++ b/__tests__/PaginationBoxView-test.js
@@ -45,4 +45,13 @@ describe('PaginationBoxView', function() {
 
     expect(pagination.getDOMNode().querySelector(".selected a").textContent).toBe("3");
   });
+
+  it('test rendering only active page item', function() {
+    var smallPagination = TestUtils.renderIntoDocument(
+      <PaginationBoxView pageRangeDisplayed={0} marginPagesDisplayed={0} initialSelected={1} />
+    );
+    var pageItems = smallPagination.getDOMNode().querySelectorAll("li");
+    // Prev, current, next
+    expect(pageItems.length).toBe(3);
+  });
 });

--- a/react_components/PaginationListView.js
+++ b/react_components/PaginationListView.js
@@ -63,7 +63,7 @@ var PaginationListView = React.createClass({
           continue;
         }
 
-        if ((page >= this.props.selected - leftSide) && (index <= this.props.selected + rightSide)) {
+        if ((index >= this.props.selected - leftSide) && (index <= this.props.selected + rightSide)) {
           items[String(index)] = pageView;
           continue;
         }


### PR DESCRIPTION
Dont render page `selected - 1` when `pageRangeDisplayed` and `marginPagesDisplayed` is zero.
Will allow paginations of just `<`, `current`, `>`.

The issue happens when the selected page is 1 (or more).