### PR TITLE
Refactor handling of navigation pages

### DIFF
--- a/dist/PaginationBoxView.js
+++ b/dist/PaginationBoxView.js
@@ -39,7 +39,7 @@ var PaginationBoxView = React.createClass({
     };
   },
 
-  callClickCallback: function callClickCallback() {
+  clickCallback: function clickCallback() {
     if (typeof this.props.clickCallback !== 'undefined' && typeof this.props.clickCallback === 'function') {
       this.props.clickCallback({ selected: this.state.selected });
     }
@@ -52,9 +52,7 @@ var PaginationBoxView = React.createClass({
 
     var needToUpdate = this.state.selected !== selected;
     if (needToUpdate) {
-      this.setState({ selected: selected }, this.callClickCallback);
-    } else {
-      this.callClickCallback();
+      this.setState({ selected: selected }, this.clickCallback);
     }
   },
 

--- a/dist/PaginationBoxView.js
+++ b/dist/PaginationBoxView.js
@@ -50,8 +50,8 @@ var PaginationBoxView = React.createClass({
       event.preventDefault();
     }
 
-    var needToUpdate = this.state.selected !== selected;
-    if (needToUpdate) {
+    var pageChanged = this.state.selected !== selected;
+    if (pageChanged) {
       this.setState({ selected: selected }, this.clickCallback);
     }
   },

--- a/dist/PaginationBoxView.js
+++ b/dist/PaginationBoxView.js
@@ -39,29 +39,46 @@ var PaginationBoxView = React.createClass({
     };
   },
 
-  handlePageSelected: function handlePageSelected(selected, event) {
-    event.preventDefault();
-
-    if (this.state.selected === selected) return;
-
-    this.setState({ selected: selected });
-
+  callClickCallback: function callClickCallback() {
     if (typeof this.props.clickCallback !== 'undefined' && typeof this.props.clickCallback === 'function') {
-      this.props.clickCallback({ selected: selected });
+      this.props.clickCallback({ selected: this.state.selected });
+    }
+  },
+
+  handlePageSelected: function handlePageSelected(selected, event) {
+    if (typeof event !== 'undefined') {
+      event.preventDefault();
+    }
+
+    var needToUpdate = this.state.selected !== selected;
+    if (needToUpdate) {
+      this.setState({ selected: selected }, this.callClickCallback);
+    } else {
+      this.callClickCallback();
     }
   },
 
   handlePreviousPage: function handlePreviousPage(event) {
     event.preventDefault();
+
     if (this.state.selected > 0) {
-      this.handlePageSelected(this.state.selected - 1, event);
+      this.setState(function (previousState, currentProps) {
+        return { selected: previousState.selected - 1 };
+      }, (function () {
+        this.handlePageSelected(this.state.selected);
+      }).bind(this));
     }
   },
 
   handleNextPage: function handleNextPage(event) {
     event.preventDefault();
+
     if (this.state.selected < this.props.pageNum - 1) {
-      this.handlePageSelected(this.state.selected + 1, event);
+      this.setState(function (previousState, currentProps) {
+        return { selected: previousState.selected + 1 };
+      }, (function () {
+        this.handlePageSelected(this.state.selected);
+      }).bind(this));
     }
   },
 

--- a/dist/PaginationBoxView.js
+++ b/dist/PaginationBoxView.js
@@ -42,9 +42,9 @@ var PaginationBoxView = React.createClass({
   handlePageSelected: function handlePageSelected(selected, event) {
     event.preventDefault();
 
-    if (this.state.selected === selected) {
-      return;
-    }this.setState({ selected: selected });
+    if (this.state.selected === selected) return;
+
+    this.setState({ selected: selected });
 
     if (typeof this.props.clickCallback !== 'undefined' && typeof this.props.clickCallback === 'function') {
       this.props.clickCallback({ selected: selected });
@@ -67,13 +67,13 @@ var PaginationBoxView = React.createClass({
 
   render: function render() {
     var previousClasses = classNames({
-      previous: true,
-      disabled: this.state.selected === 0
+      'previous': true,
+      'disabled': this.state.selected === 0
     });
 
     var nextClasses = classNames({
-      next: true,
-      disabled: this.state.selected === this.props.pageNum - 1
+      'next': true,
+      'disabled': this.state.selected === this.props.pageNum - 1
     });
 
     return React.createElement(

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -38,30 +38,50 @@ var PaginationBoxView = React.createClass({
     };
   },
 
+  callClickCallback: function() {
+    if (typeof this.props.clickCallback !== "undefined" &&
+        typeof this.props.clickCallback === "function") {
+      this.props.clickCallback({ selected: this.state.selected });
+    }
+  },
+
   handlePageSelected: function(selected, event) {
-    event.preventDefault();
+    if (typeof event !== "undefined") {
+      event.preventDefault();
+    }
 
-    if (this.state.selected === selected) return;
-
-    this.setState({selected: selected});
-
-    if (typeof(this.props.clickCallback) !== "undefined" &&
-        typeof(this.props.clickCallback) === "function") {
-      this.props.clickCallback({selected: selected});
+    var needToUpdate = this.state.selected !== selected;
+    if (needToUpdate) {
+      this.setState({ selected: selected }, this.callClickCallback);
+    }
+    else {
+      this.callClickCallback();
     }
   },
 
   handlePreviousPage: function(event) {
     event.preventDefault();
+
     if (this.state.selected > 0) {
-      this.handlePageSelected(this.state.selected - 1, event);
+      this.setState(
+        function (previousState, currentProps) { return { selected: previousState.selected - 1 } },
+        function () {
+          this.handlePageSelected(this.state.selected);
+        }.bind(this)
+      );
     }
   },
 
   handleNextPage: function(event) {
     event.preventDefault();
+
     if (this.state.selected < this.props.pageNum - 1) {
-      this.handlePageSelected(this.state.selected + 1, event);
+      this.setState(
+        function (previousState, currentProps) { return { selected: previousState.selected + 1 } },
+        function () {
+          this.handlePageSelected(this.state.selected);
+        }.bind(this)
+      );
     }
   },
 

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -50,8 +50,8 @@ var PaginationBoxView = React.createClass({
       event.preventDefault();
     }
 
-    var needToUpdate = this.state.selected !== selected;
-    if (needToUpdate) {
+    var pageChanged = this.state.selected !== selected;
+    if (pageChanged) {
       this.setState({ selected: selected }, this.clickCallback);
     }
   },

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -38,7 +38,7 @@ var PaginationBoxView = React.createClass({
     };
   },
 
-  callClickCallback: function() {
+  clickCallback: function() {
     if (typeof this.props.clickCallback !== "undefined" &&
         typeof this.props.clickCallback === "function") {
       this.props.clickCallback({ selected: this.state.selected });
@@ -52,10 +52,7 @@ var PaginationBoxView = React.createClass({
 
     var needToUpdate = this.state.selected !== selected;
     if (needToUpdate) {
-      this.setState({ selected: selected }, this.callClickCallback);
-    }
-    else {
-      this.callClickCallback();
+      this.setState({ selected: selected }, this.clickCallback);
     }
   },
 


### PR DESCRIPTION
React manages the update of `state`s through a queue. To be sure they already have been updated correctly before than retrieving them, it's better using the callbacks provided by `getState`.