### PR TITLE
IE 9 compatibility

### DIFF
--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -71,7 +71,12 @@ export default class PaginationBoxView extends Component {
   }
 
   handlePageSelected = (selected, evt) => {
-    evt.preventDefault();
+    if (evt.preventDefault) {
+      evt.preventDefault();
+    } else {
+      evt.returnValue = false;
+      event.cancelBubble = true;
+    }
 
     if (this.state.selected === selected) return;
 


### PR DESCRIPTION
Use `event.returnValue = false` instead of `event.preventDefault()` for IE under version 10
