### PR TITLE
Wrapped PaginationListView in <li> tag.

### DIFF
--- a/dist/PaginationBoxView.js
+++ b/dist/PaginationBoxView.js
@@ -142,18 +142,22 @@ var PaginationBoxView = (function (_Component) {
             this.props.previousLabel
           )
         ),
-        _react2['default'].createElement(_PaginationListView2['default'], {
-          onPageSelected: this.handlePageSelected,
-          selected: this.state.selected,
-          pageNum: this.props.pageNum,
-          pageRangeDisplayed: this.props.pageRangeDisplayed,
-          marginPagesDisplayed: this.props.marginPagesDisplayed,
-          breakLabel: this.props.breakLabel,
-          subContainerClassName: this.props.subContainerClassName,
-          pageClassName: this.props.pageClassName,
-          pageLinkClassName: this.props.pageLinkClassName,
-          activeClassName: this.props.activeClassName,
-          disabledClassName: this.props.disabledClassName }),
+        _react2['default'].createElement(
+          'li',
+          null,
+          _react2['default'].createElement(_PaginationListView2['default'], {
+            onPageSelected: this.handlePageSelected,
+            selected: this.state.selected,
+            pageNum: this.props.pageNum,
+            pageRangeDisplayed: this.props.pageRangeDisplayed,
+            marginPagesDisplayed: this.props.marginPagesDisplayed,
+            breakLabel: this.props.breakLabel,
+            subContainerClassName: this.props.subContainerClassName,
+            pageClassName: this.props.pageClassName,
+            pageLinkClassName: this.props.pageLinkClassName,
+            activeClassName: this.props.activeClassName,
+            disabledClassName: this.props.disabledClassName })
+        ),
         _react2['default'].createElement(
           'li',
           { onClick: this.handleNextPage, className: nextClasses },

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -103,18 +103,20 @@ export default class PaginationBoxView extends Component {
           <a href="" className={this.props.previousLinkClassName}>{this.props.previousLabel}</a>
         </li>
 
-        <PaginationListView
-          onPageSelected={this.handlePageSelected}
-          selected={this.state.selected}
-          pageNum={this.props.pageNum}
-          pageRangeDisplayed={this.props.pageRangeDisplayed}
-          marginPagesDisplayed={this.props.marginPagesDisplayed}
-          breakLabel={this.props.breakLabel}
-          subContainerClassName={this.props.subContainerClassName}
-          pageClassName={this.props.pageClassName}
-          pageLinkClassName={this.props.pageLinkClassName}
-          activeClassName={this.props.activeClassName}
-          disabledClassName={this.props.disabledClassName} />
+        <li>
+          <PaginationListView
+            onPageSelected={this.handlePageSelected}
+            selected={this.state.selected}
+            pageNum={this.props.pageNum}
+            pageRangeDisplayed={this.props.pageRangeDisplayed}
+            marginPagesDisplayed={this.props.marginPagesDisplayed}
+            breakLabel={this.props.breakLabel}
+            subContainerClassName={this.props.subContainerClassName}
+            pageClassName={this.props.pageClassName}
+            pageLinkClassName={this.props.pageLinkClassName}
+            activeClassName={this.props.activeClassName}
+            disabledClassName={this.props.disabledClassName} />
+        </li>
 
         <li onClick={this.handleNextPage} className={nextClasses}>
           <a href="" className={this.props.nextLinkClassName}>{this.props.nextLabel}</a>


### PR DESCRIPTION
Fix for #19.

Wrapped the PaginationListView component in an `<li>` tag so the PaginationListView's `<ul>` tag isn't a direct child of the PaginationBoxView's `<ul>` tag.