### PR TITLE
babel-cli added to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-dom": "^0.14.6"
   },
   "devDependencies": {
+    "babel-cli": "^6.4.5",
     "babel-core": "^6.4.5",
     "babel-jest": "^6.0.1",
     "babel-loader": "^6.2.1",


### PR DESCRIPTION
Running `npm i` ends with an error: 

    > babel ./react_components --out-dir ./dist --source-maps --presets es2015,stage-0,react
    sh: 1: babel: not found

I would be good to add babel-cli to devDependencies. Alternatively, there could be requirements section with info that babel needs to be installed globally. 