### PR TITLE
Create a data directory for demo

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -17,7 +17,13 @@ function generateData() {
     });
   }
 
-  fs.writeFileSync(path.join(__dirname, 'data', 'data.json'),
+  var dataDir = path.join(__dirname, 'data');
+  try {
+    fs.mkdirSync(dataDir);
+  } catch (e) {
+    if (e.code != 'EEXIST') throw e;
+  }
+  fs.writeFileSync(path.join(dataDir, 'data.json'),
                    JSON.stringify(comments, null, 2));
 
 };


### PR DESCRIPTION
I get an error while preparing a demo `make demo`. This change creates a `data` dir before creating a file. 

```
> make demo       
cd demo && webpack
Hash: 3318be4fa6c418ae1bc1
Version: webpack 1.12.12
Time: 2820ms
      Asset     Size  Chunks             Chunk Names
    demo.js   974 kB       0  [emitted]  main
demo.js.map  1.16 MB       0  [emitted]  main
    + 167 hidden modules
node demo/data.js
fs.js:584
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open '/home/user1/react-paginate-platan/demo/data/data.json'
    at Error (native)
    at Object.fs.openSync (fs.js:584:18)
    at Object.fs.writeFileSync (fs.js:1224:33)
    at generateData (/home/user1/react-paginate-platan/demo/data.js:20:6)
    at Object.<anonymous> (/home/user1/react-paginate-platan/demo/data.js:25:1)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
make: *** [demo] Błąd 1
```