### PR TITLE
Babellrc presets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": [
     "react",
-    "es2015"
+    "es2015",
+    "stage-0"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ $ cd react-paginate
 
 Install dependencies:
 
+```console
+$ make install
+```
+
 Prepare the demo:
 
 ```console


### PR DESCRIPTION
The `.babelrc` file overrides the options passed in the npm `prepublish` task. An error _(see below)_ would occur when installing the dependencies because the `stage-0` preset was missing. 
Also, updated the readme to include the (npm) install step.

```console
> react-paginate@0.5.2 prepublish /Users/mbrady/sites/matbrady/react-paginate
> babel ./react_components --out-dir ./dist --source-maps --presets es2015,stage-0,react

react_components/PageView.js -> dist/PageView.js
SyntaxError: react_components/PaginationBoxView.js: Missing class properties transform.
   7 | 
   8 | export default class PaginationBoxView extends Component {
>  9 |   static propTypes = {
     |   ^
  10 |     pageNum               : PropTypes.number.isRequired,
  11 |     pageRangeDisplayed    : PropTypes.number.isRequired,
  12 |     marginPagesDisplayed  : PropTypes.number.isRequired,

npm ERR! Darwin 14.5.0
npm ERR! argv "/Users/mbrady/.nvm/versions/node/v4.2.1/bin/node" "/Users/mbrady/.nvm/versions/node/v4.2.1/bin/npm" "run" "prepublish"
npm ERR! node v4.2.1
npm ERR! npm  v2.14.7
npm ERR! code ELIFECYCLE
npm ERR! react-paginate@0.5.2 prepublish: `babel ./react_components --out-dir ./dist --source-maps --presets es2015,stage-0,react`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the react-paginate@0.5.2 prepublish script 'babel ./react_components --out-dir ./dist --source-maps --presets es2015,stage-0,react'.
npm ERR! This is most likely a problem with the react-paginate package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     babel ./react_components --out-dir ./dist --source-maps --presets es2015,stage-0,react
npm ERR! You can get their info via:
npm ERR!     npm owner ls react-paginate
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/mbrady/sites/matbrady/react-paginate/npm-debug.log
```