### PR TITLE
adding `demo` npm script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 
 .PHONY: demo
 demo:
-	cd demo && webpack
+	cd demo && npm run demo
 	node demo/data.js
 
 .PHONY: serve

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "scripts": {
     "test": "BABEL_JEST_STAGE=0 jest",
     "prepublish": "babel ./react_components --out-dir ./dist --source-maps --presets es2015,stage-0,react",
-    "start": "webpack-dev-server --hot --inline"
+    "start": "webpack-dev-server --hot --inline",
+    "demo": "webpack"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",


### PR DESCRIPTION
Running `make demo` returns and error if webpack is not installed globally. This PR just adds a npm script to use the webpack version defined in the `package.json` file. 

```console
$ [react-paginate] make demo
cd demo && webpack
/bin/sh: webpack: command not found
make: *** [demo] Error 127
```