### PR TITLE
node version 4.1 in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+node_js:
+  - "4.1"


### PR DESCRIPTION
Currently travis build is failing: https://travis-ci.org/AdeleD/react-paginate/builds/108731997. It's using node v0.10.42. 
Maybe we should use newer node's version? https://travis-ci.org/platan/react-paginate/builds/108888780
Version 4.1 is the newest one in travis: https://docs.travis-ci.com/user/languages/javascript-with-nodejs