### PR TITLE
Fix disabled custom class name not applied

### DIFF
--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -176,10 +176,10 @@ export default class PaginationBoxView extends Component {
     let disabled = this.props.disabledClassName;
 
     const previousClasses = classNames(this.props.previousClassName,
-                                       {disabled: this.state.selected === 0});
+                                       {[disabled]: this.state.selected === 0});
 
     const nextClasses = classNames(this.props.nextClassName,
-                                   {disabled: this.state.selected === this.props.pageNum - 1});
+                                   {[disabled]: this.state.selected === this.props.pageNum - 1});
 
     return (
       <ul className={this.props.containerClassName}>


### PR DESCRIPTION
This update fixes the problem of custom disabled class name not applied.

When you have `classNames({ disabled: true })`, you will always get the string `"disabled"`.
But when you do `classNames({ [disabled]: true })`, you get the actual variable `disabled`.