### PR TITLE
Remove empty hrefs, fixes page reloads on click

### DIFF
--- a/react_components/PageView.js
+++ b/react_components/PageView.js
@@ -17,7 +17,7 @@ export default class PageView extends React.Component {
 
     return (
         <li className={cssClassName}>
-            <a {...this.props} href="" className={linkClassName}>
+            <a {...this.props} className={linkClassName}>
               {this.props.page}
             </a>
         </li>

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -184,13 +184,13 @@ export default class PaginationBoxView extends Component {
     return (
       <ul className={this.props.containerClassName}>
         <li onClick={this.handlePreviousPage} className={previousClasses}>
-          <a href="" className={this.props.previousLinkClassName}>{this.props.previousLabel}</a>
+          <a className={this.props.previousLinkClassName}>{this.props.previousLabel}</a>
         </li>
 
         {createFragment(this.pagination())}
 
         <li onClick={this.handleNextPage} className={nextClasses}>
-          <a href="" className={this.props.nextLinkClassName}>{this.props.nextLabel}</a>
+          <a className={this.props.nextLinkClassName}>{this.props.nextLabel}</a>
         </li>
       </ul>
     );


### PR DESCRIPTION
`href` is not a [required](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) attribute

I'm removing the hrefs, because its causing a page reload on each click for me.

An alternative is to use `href=#`, but `href=""` creates undesirable reloads.