### PR TITLE
use the "forceSelected" property also on component updates, not only …

### DIFF
--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -61,6 +61,12 @@ export default class PaginationBoxView extends Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.forceSelected !== nextProps.forceSelected) {
+      this.setState({selected: nextProps.forceSelected});
+    }
+  }
+
   handlePreviousPage = evt => {
     evt.preventDefault ? evt.preventDefault() : (evt.returnValue = false);
     if (this.state.selected > 0) {


### PR DESCRIPTION
…on component mount

Currently, the `forceSelected` property is only evaluated on _mount_ of the component, but if you have a property which lets you set the selected state from external (and that's what I expect from `forceSelected`), it should also be used when component _updates/receives new props_.
There are situations, which need to control the pagination component also from outside, not only within the component itself.