### PR TITLE
Fix cannot resolve module 'react-addons-create-fragment' issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "serve-static": "^1.10.2",
     "webpack": "^1.12.14",
     "webpack-dev-middleware": "^1.5.1",
-    "webpack-dev-server": "^1.14.1"
+    "webpack-dev-server": "^1.14.1",
+    "react-addons-create-fragment": "^15.0.1"
   },
   "scripts": {
     "test": "BABEL_JEST_STAGE=0 jest",


### PR DESCRIPTION
When I clone react-paginate and `make install` is OK, but when I run `make demo` there was an error output:

```
ERROR in ./react_components/PaginationBoxView.js
Module not found: Error: Cannot resolve module 'react-addons-create-fragment' in /home/allen/Sites/github/react-paginate/react_components
 @ ./react_components/PaginationBoxView.js 19:33-72
```