### PR TITLE
Make peerDependencies more flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-paginate",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A ReactJS component that creates a pagination.",
   "main": "./dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "classnames": "^1.2.2"
   },
   "peerDependencies": {
-    "react-addons-create-fragment": "~15.0.0",
-    "react-dom": "~15.0.0"
+    "react-addons-create-fragment": "^15.0.0",
+    "react-dom": "^15.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",


### PR DESCRIPTION
Current version of react-dom is 15.1.0
~15.0.0 will match all 15.0.x versions but will miss 15.1.0
^15.0.0 will match any 15.x.x release including 15.1.0, but will hold off on 16.0.0