### PR TITLE
Add keyboard support for pagination

### DIFF
--- a/react_components/PageView.js
+++ b/react_components/PageView.js
@@ -17,7 +17,7 @@ export default class PageView extends React.Component {
     }
 
     return (
-        <li onClick={onClick} className={cssClassName}>
+        <li onClick={onClick} className={cssClassName} tabIndex="0" onKeyPress={onClick}>
             <a className={linkClassName}>
               {this.props.page}
             </a>

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -192,13 +192,21 @@ export default class PaginationBoxView extends Component {
 
     return (
       <ul className={this.props.containerClassName}>
-        <li onClick={this.handlePreviousPage} className={previousClasses}>
+        <li
+          onClick={this.handlePreviousPage}
+          className={previousClasses}
+          tabIndex="0"
+          onKeyPress={this.handlePreviousPage}>
           <a className={this.props.previousLinkClassName}>{this.props.previousLabel}</a>
         </li>
 
         {createFragment(this.pagination())}
 
-        <li onClick={this.handleNextPage} className={nextClasses}>
+        <li
+          onClick={this.handleNextPage}
+          className={nextClasses}
+          tabIndex="0"
+          onKeyPress={this.handleNextPage}>
           <a className={this.props.nextLinkClassName}>{this.props.nextLabel}</a>
         </li>
       </ul>


### PR DESCRIPTION
Fixes #89 

Ideally I would want to move the `onClick` events to `a` tag rather than the `li`. Did not do that since I was not sure whether it could have breaking impact to others.

@AdeleD @coljung If you think its okay to make the handlers to `a` tag, let me know. I will make the appropriate change.