### PR TITLE
fix README to include react-addons-create-fragment during npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ or
 Install `react-paginate` with [npm](https://www.npmjs.com/):
 
 ```
-$ npm install react-paginate --save
+$ npm install react-paginate react-addons-create-fragment --save
 ```
 
 For [CommonJS](http://wiki.commonjs.org/wiki/CommonJS) users:


### PR DESCRIPTION
Issue: https://github.com/AdeleD/react-paginate/issues/127