### PR TITLE
Improve screen reader readibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-paginate",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "A ReactJS component that creates a pagination.",
   "main": "./dist/index.js",
   "repository": {

--- a/react_components/PageView.js
+++ b/react_components/PageView.js
@@ -7,8 +7,11 @@ export default class PageView extends React.Component {
     let linkClassName = this.props.pageLinkClassName;
     let cssClassName = this.props.pageClassName;
     let onClick = this.props.onClick;
+    let ariaLabel = 'Page ' + this.props.page +
+      (this.props.extraAriaContext ? ' ' + this.props.extraAriaContext : '');
 
     if (this.props.selected) {
+      ariaLabel = 'Page ' + this.props.page + ' is your current page';
       if (typeof(cssClassName) !== 'undefined') {
         cssClassName = cssClassName + ' ' + this.props.activeClassName;
       } else {
@@ -21,6 +24,7 @@ export default class PageView extends React.Component {
             <a onClick={onClick}
                className={linkClassName}
                tabIndex="0"
+               aria-label={ariaLabel}
                onKeyPress={onClick}>
               {this.props.page}
             </a>

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -113,6 +113,7 @@ export default class PaginationBoxView extends Component {
           pageClassName={this.props.pageClassName}
           pageLinkClassName={this.props.pageLinkClassName}
           activeClassName={this.props.activeClassName}
+          extraAriaContext={this.props.extraAriaContext}
           page={index + 1} />
       }
 
@@ -145,6 +146,7 @@ export default class PaginationBoxView extends Component {
             pageClassName={this.props.pageClassName}
             pageLinkClassName={this.props.pageLinkClassName}
             activeClassName={this.props.activeClassName}
+            extraAriaContext={this.props.extraAriaContext}
             page={index + 1} />
         );
 


### PR DESCRIPTION
When using a screen reader to view pages using react-paginate, currently all of
the page number links will only say the page number. It would be nice if the
currently selected page number also said "Page PAGE_NUMBER is your current
page". This can be accomplished using the `aria-label` attribute. It would
further help some users if the consumers of react-paginate could add some extra
text to the end of the `aria-label` to provide additional context to the users.
This context could include things like the page title, or whatever the consumer
wanted.