### PR TITLE
fix bug #127: missing react-addons-create-fragment and react dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "url": "https://github.com/AdeleD/react-paginate/issues"
   },
   "dependencies": {
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "react": "^15.0.0",
+    "react-addons-create-fragment": "^15.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
@@ -34,8 +36,6 @@
     "express": "^4.14.0",
     "jest-cli": "^17.0.3",
     "jquery": "^3.1.1",
-    "react": "^15.0.0",
-    "react-addons-create-fragment": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",
     "react-hot-loader": "^1.3.1",


### PR DESCRIPTION
react-addons-create-fragment is used in react_components/PaginationBoxView.js, so it should also carried as dependency in package.json.