### PR TITLE
convert from class to stateless component & fix warning in tests

### DIFF
--- a/__tests__/PaginationBoxView-test.js
+++ b/__tests__/PaginationBoxView-test.js
@@ -9,7 +9,7 @@ const PaginationBoxView = require('./../react_components/PaginationBoxView').def
 const PageView = require('./../react_components/PageView').default;
 const BreakView = require('./../react_components/BreakView').default;
 
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 
 describe('PaginationBoxView', () => {
   const pagination = ReactTestUtils.renderIntoDocument(

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "express": "^4.14.0",
     "jest-cli": "^17.0.3",
     "jquery": "^3.1.1",
-    "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",
     "react-hot-loader": "^1.3.1",
     "serve-static": "^1.11.1",
@@ -51,12 +50,13 @@
     "demo": "webpack"
   },
   "jest": {
-    "transform": {".*": "<rootDir>/node_modules/babel-jest"},
+    "transform": {
+      ".*": "<rootDir>/node_modules/babel-jest"
+    },
     "testPathDirs": ["__tests__"],
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/react",
       "<rootDir>/node_modules/react-dom",
-      "<rootDir>/node_modules/react-addons-test-utils",
       "<rootDir>/node_modules/fbjs"
     ],
     "modulePathIgnorePatterns": [

--- a/react_components/BreakView.js
+++ b/react_components/BreakView.js
@@ -2,15 +2,15 @@
 
 import React from 'react';
 
-export default class BreakView extends React.Component {
-  render() {
-    let label = this.props.breakLabel;
-    let className = this.props.breakClassName || 'break';
+const BreakView = (props) => {
+  const label = props.breakLabel;
+  const className = props.breakClassName || 'break';
 
-    return (
-      <li className={className}>
-        {label}
-      </li>
-    );
-  }
-};
+  return (
+    <li className={className}>
+      {label}
+    </li>
+  );
+}
+
+export default BreakView;

--- a/react_components/PageView.js
+++ b/react_components/PageView.js
@@ -2,38 +2,38 @@
 
 import React from 'react';
 
-export default class PageView extends React.Component {
-  render() {
-    let cssClassName = this.props.pageClassName;
-    const linkClassName = this.props.pageLinkClassName;
-    const onClick = this.props.onClick;
-    const href = this.props.href;
-    let ariaLabel = 'Page ' + this.props.page +
-      (this.props.extraAriaContext ? ' ' + this.props.extraAriaContext : '');
-    let ariaCurrent = null;
+const PageView = (props) => {
+  let cssClassName = props.pageClassName;
+  const linkClassName = props.pageLinkClassName;
+  const onClick = props.onClick;
+  const href = props.href;
+  let ariaLabel = 'Page ' + props.page +
+    (props.extraAriaContext ? ' ' + props.extraAriaContext : '');
+  let ariaCurrent = null;
 
-    if (this.props.selected) {
-      ariaCurrent = 'page';
-      ariaLabel = 'Page ' + this.props.page + ' is your current page';
-      if (typeof(cssClassName) !== 'undefined') {
-        cssClassName = cssClassName + ' ' + this.props.activeClassName;
-      } else {
-        cssClassName = this.props.activeClassName;
-      }
+  if (props.selected) {
+    ariaCurrent = 'page';
+    ariaLabel = 'Page ' + props.page + ' is your current page';
+    if (typeof(cssClassName) !== 'undefined') {
+      cssClassName = cssClassName + ' ' + props.activeClassName;
+    } else {
+      cssClassName = props.activeClassName;
     }
-
-    return (
-        <li className={cssClassName}>
-            <a onClick={onClick}
-               className={linkClassName}
-               href={href}
-               tabIndex="0"
-               aria-label={ariaLabel}
-               aria-current={ariaCurrent}
-               onKeyPress={onClick}>
-              {this.props.page}
-            </a>
-        </li>
-    );
   }
-};
+
+  return (
+      <li className={cssClassName}>
+          <a onClick={onClick}
+             className={linkClassName}
+             href={href}
+             tabIndex="0"
+             aria-label={ariaLabel}
+             aria-current={ariaCurrent}
+             onKeyPress={onClick}>
+            {props.page}
+          </a>
+      </li>
+  )
+}
+
+export default PageView;


### PR DESCRIPTION
- convert `BreakView.js` and `PageView.js` from `class` to a stateless function
- remove `react-addons-test-utils` as its [deprecated](https://facebook.github.io/react/docs/test-utils.html).