### PR TITLE
Update devDependencies to fix `make serve`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,8 @@
     "prop-types": "^15.6.0",
     "react-addons-create-fragment": "^15.0.0"
   },
-  "peerDependencies": {
-    "react": "^16.0.0"
-  },
   "devDependencies": {
+    "react": "^16.0.0",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-jest": "^17.0.2",


### PR DESCRIPTION
Moves react to a dev dep to allow for webpack to compile correctly fixing errors when running `make serve` to fix issue #157 