### PR TITLE
Aria label builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Open your browser and go to [http://localhost:3000/](http://localhost:3000/)
 | `disabledClassName`       | `String`    | The classname for disabled `previous` and `next` buttons.                                     |
 | `hrefBuilder`             | `Function`  | The method is called to generate the `href` attribute value on tag `a` of each page element.  |
 | `extraAriaContext`        | `String`    | Extra context to add to the `aria-label` HTML attribute.                                      |
+| `ariaLabelBuilder`        | `Function`  | The method is called to generate the `aria-label` attribute value on each page link           |
 
 ## Contribute
 

--- a/__tests__/PaginationBoxView-test.js
+++ b/__tests__/PaginationBoxView-test.js
@@ -96,6 +96,41 @@ describe('PaginationBoxView', () => {
       .hasAttribute('href')).toBe(false);
   });
 
+  it('should use ariaLabelBuilder for rendering aria-labels if ariaLabelBuilder is specified', function() {
+    const linkedPagination = ReactTestUtils.renderIntoDocument(
+      <PaginationBoxView
+        initialPage={1}
+        pageCount={3}
+        pageRangeDisplayed={2}
+        marginPagesDisplayed={2}
+        ariaLabelBuilder={(page, selected) => selected ? 'Current page' : 'Goto page ' + page } />
+    );
+    expect(ReactDOM.findDOMNode(linkedPagination).querySelector('li:nth-last-child(2) a')
+      .getAttribute('aria-label')).toBe('Goto page 3');
+    expect(ReactDOM.findDOMNode(linkedPagination).querySelector('li:nth-child(2) a')
+      .getAttribute('aria-label')).toBe('Goto page 1');
+    expect(ReactDOM.findDOMNode(linkedPagination).querySelector('.selected a')
+      .getAttribute('aria-label')).toBe('Current page');
+  });
+
+  it('test ariaLabelBuilder works with extraAriaContext', function() {
+    const linkedPagination = ReactTestUtils.renderIntoDocument(
+      <PaginationBoxView
+        initialPage={1}
+        pageCount={3}
+        pageRangeDisplayed={2}
+        marginPagesDisplayed={2}
+        ariaLabelBuilder={(page, selected) => selected ? 'Current page' : 'Goto page ' + page }
+        extraAriaContext="foobar" />
+    );
+    expect(ReactDOM.findDOMNode(linkedPagination).querySelector('li:nth-last-child(2) a')
+      .getAttribute('aria-label')).toBe('Goto page 3 foobar');
+    expect(ReactDOM.findDOMNode(linkedPagination).querySelector('li:nth-child(2) a')
+      .getAttribute('aria-label')).toBe('Goto page 1 foobar');
+    expect(ReactDOM.findDOMNode(linkedPagination).querySelector('.selected a')
+      .getAttribute('aria-label')).toBe('Current page');
+  });
+
   it('test breakClassName rendering', function() {
     const smallPagination = ReactTestUtils.renderIntoDocument(
       <PaginationBoxView breakClassName={"break-me"}/>

--- a/react_components/PageView.js
+++ b/react_components/PageView.js
@@ -7,13 +7,13 @@ const PageView = (props) => {
   const linkClassName = props.pageLinkClassName;
   const onClick = props.onClick;
   const href = props.href;
-  let ariaLabel = 'Page ' + props.page +
+  let ariaLabel = props.ariaLabel || 'Page ' + props.page +
     (props.extraAriaContext ? ' ' + props.extraAriaContext : '');
   let ariaCurrent = null;
 
   if (props.selected) {
     ariaCurrent = 'page';
-    ariaLabel = 'Page ' + props.page + ' is your current page';
+    ariaLabel = props.ariaLabel || 'Page ' + props.page + ' is your current page';
     if (typeof(cssClassName) !== 'undefined') {
       cssClassName = cssClassName + ' ' + props.activeClassName;
     } else {

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -31,7 +31,9 @@ export default class PaginationBoxView extends Component {
     previousLinkClassName : PropTypes.string,
     nextLinkClassName     : PropTypes.string,
     disabledClassName     : PropTypes.string,
-    breakClassName        : PropTypes.string
+    breakClassName        : PropTypes.string,
+    extraAriaContext      : PropTypes.string,
+    ariaLabelBuilder      : PropTypes.func
   };
 
   static defaultProps = {
@@ -106,6 +108,20 @@ export default class PaginationBoxView extends Component {
     }
   }
 
+  ariaLabelBuilder(pageIndex) {
+    const selected = pageIndex === this.state.selected;
+    if (this.props.ariaLabelBuilder &&
+      pageIndex >= 0 &&
+      pageIndex < this.props.pageCount) {
+      let label = this.props.ariaLabelBuilder(pageIndex + 1, selected);
+      // perhaps deprecate warning in future?
+      if (this.props.extraAriaContext && !selected) {
+        label = label + ' ' + this.props.extraAriaContext;
+      }
+      return label;
+    }
+  }
+
   callCallback = (selectedItem) => {
     if (typeof(this.props.onPageChange) !== "undefined" &&
         typeof(this.props.onPageChange) === "function") {
@@ -122,6 +138,7 @@ export default class PaginationBoxView extends Component {
       activeClassName={this.props.activeClassName}
       extraAriaContext={this.props.extraAriaContext}
       href={this.hrefBuilder(index)}
+      ariaLabel={this.ariaLabelBuilder(index)}
       page={index + 1} />
   }
 


### PR DESCRIPTION
https://github.com/AdeleD/react-paginate/issues/183

Works like hrefBuilder, except it skips next & previous because aria-label can be provided to them with previousLabel & nextLabel props.