### PR TITLE
remove unnecessary code from webpack config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,3 @@
 {
-  "presets": [
-    "react",
-    "es2015",
-    "stage-0"
-  ]
+  "presets": ["react", "es2015", "stage-0"]
 }

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -1,9 +1,5 @@
 /* global __dirname */
-
 var path = require('path');
-
-var webpack = require('webpack');
-
 var dir_js = path.resolve(__dirname, 'js');
 var dir_html = path.resolve(__dirname, 'html');
 var dir_build = path.resolve(__dirname, 'build');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 /* global __dirname */
 var path = require('path');
-var webpack = require('webpack');
 var dir_js = path.resolve(__dirname, 'react_components');
 var dir_build = path.resolve(__dirname, 'build');
 
@@ -24,9 +23,6 @@ module.exports = {
             {
                 loader: 'babel-loader',
                 test: dir_js,
-                query: {
-                    presets: ['es2015', 'react', 'stage-0'],
-                },
             }
         ]
     },


### PR DESCRIPTION
`webpack` is imported into the `webpack.config` but its no where used. If it's intended to be used then probably best use will be for [plugins](https://github.com/webpack/docs/wiki/list-of-plugins) it provides.

Also since there is a `babelrc` file the queries for presets are not needed in the webpack config.