### PR TITLE
Display prev and next buttons when necessary

### DIFF
--- a/__tests__/PaginationBoxView-test.js
+++ b/__tests__/PaginationBoxView-test.js
@@ -21,13 +21,13 @@ describe('PaginationBoxView', () => {
 
     ReactTestUtils.scryRenderedComponentsWithType(pagination, PaginationBoxView);
 
-    expect(ReactDOM.findDOMNode(pagination).querySelector("li:first-child a").textContent).toBe("Previous");
     expect(ReactDOM.findDOMNode(pagination).querySelector(".selected a").textContent).toBe("1");
     expect(ReactDOM.findDOMNode(pagination).querySelector("li:last-child a").textContent).toBe("Next");
 
     const pages = ReactDOM.findDOMNode(pagination).querySelectorAll("li");
-    // 3*2 margins + 1 break label + previous & next buttons == 9:
-    expect(pages.length).toEqual(9);
+    // being on first page selected
+    // 3*2 margins + 1 break label + next == 8:
+    expect(pages.length).toEqual(8);
   });
 
   it('test previous and next buttons', () => {
@@ -51,7 +51,7 @@ describe('PaginationBoxView', () => {
 
     ReactTestUtils.Simulate.click(pageItem);
 
-    expect(ReactDOM.findDOMNode(pagination).querySelector(".selected a").textContent).toBe("2");
+    expect(ReactDOM.findDOMNode(pagination).querySelector(".selected a").textContent).toBe("3");
   });
 
   it('test rendering only active page item', function() {
@@ -65,7 +65,7 @@ describe('PaginationBoxView', () => {
 
     const pageItems = ReactDOM.findDOMNode(smallPagination).querySelectorAll("li");
     // Prev, selected page, next
-    expect(pageItems.length).toBe(3);
+    expect(pageItems.length).toBe(2);
   });
 
   it('should render href attribute in items if hrefBuilder is specified', function() {

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -68,17 +68,10 @@ export class App extends Component {
     return (
       <div className="commentBox">
         <CommentList data={this.state.data} />
-        <ReactPaginate previousLabel={"previous"}
-                       nextLabel={"next"}
-                       breakLabel={<a href="">...</a>}
-                       breakClassName={"break-me"}
-                       pageCount={this.state.pageCount}
-                       marginPagesDisplayed={2}
-                       pageRangeDisplayed={5}
-                       onPageChange={this.handlePageClick}
-                       containerClassName={"pagination"}
-                       subContainerClassName={"pages pagination"}
-                       activeClassName={"active"} />
+        <ReactPaginate initialPage={0}
+        pageRangeDisplayed={0}
+        marginPagesDisplayed={0}
+        breakLabel={null}  />
       </div>
     );
   }

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -129,13 +129,10 @@ export default class PaginationBoxView extends Component {
     let items = {};
 
     if (this.props.pageCount <= this.props.pageRangeDisplayed) {
-
       for (let index = 0; index < this.props.pageCount; index++) {
         items['key' + index] = this.getPageElement(index);
       }
-
     } else {
-
       let leftSide  = (this.props.pageRangeDisplayed / 2);
       let rightSide = (this.props.pageRangeDisplayed - leftSide);
 
@@ -154,9 +151,7 @@ export default class PaginationBoxView extends Component {
       let createPageView = (index) => this.getPageElement(index);
 
       for (index = 0; index < this.props.pageCount; index++) {
-
         page = index + 1;
-
         if (page <= this.props.marginPagesDisplayed) {
           items['key' + index] = createPageView(index);
           continue;
@@ -193,37 +188,48 @@ export default class PaginationBoxView extends Component {
   };
 
   render() {
-    let disabled = this.props.disabledClassName;
+    const disabled = this.props.disabledClassName;
+    const { selected } = this.state;
+    const {
+      previousClassName,
+      pageCount,
+      nextClassName,
+      containerClassName,
+      previousLinkClassName,
+      previousLabel,
+      nextLinkClassName,
+      nextLabel
+     } = this.props;
 
-    const previousClasses = classNames(this.props.previousClassName,
-                                       {[disabled]: this.state.selected === 0});
+    const previousClasses = classNames(previousClassName,
+                                       {[disabled]: selected === 0});
 
-    const nextClasses = classNames(this.props.nextClassName,
-                                   {[disabled]: this.state.selected === this.props.pageCount - 1});
+    const nextClasses = classNames(nextClassName,
+                                   {[disabled]: selected === pageCount - 1});
 
     return (
-      <ul className={this.props.containerClassName}>
-        <li className={previousClasses}>
+      <ul className={containerClassName}>
+        {(selected !== 0) && (<li className={previousClasses}>
           <a onClick={this.handlePreviousPage}
-             className={this.props.previousLinkClassName}
-             href={this.hrefBuilder(this.state.selected - 1)}
+             className={previousLinkClassName}
+             href={this.hrefBuilder(selected - 1)}
              tabIndex="0"
              onKeyPress={this.handlePreviousPage}>
-            {this.props.previousLabel}
+            {previousLabel}
           </a>
-        </li>
+        </li>)}
 
         {createFragment(this.pagination())}
 
-        <li className={nextClasses}>
+        {(selected !== pageCount -1) && (<li className={nextClasses}>
           <a onClick={this.handleNextPage}
-             className={this.props.nextLinkClassName}
-             href={this.hrefBuilder(this.state.selected + 1)}
-             tabIndex="0"
-             onKeyPress={this.handleNextPage}>
-            {this.props.nextLabel}
+            className={nextLinkClassName}
+            href={this.hrefBuilder(selected + 1)}
+            tabIndex="0"
+            onKeyPress={this.handleNextPage}>
+            {nextLabel}
           </a>
-        </li>
+        </li>)}
       </ul>
     );
   }


### PR DESCRIPTION
Display prev button, only if the user has clicked on a page that is not the 1st page, showing prev button in this scenario is kind weird. 
The same goes for next, if user is on the last page, showing next button does not make sense.

And also small refactors.