### PR TITLE
Fix disabled classname prop bis

### DIFF
--- a/__tests__/PaginationBoxView-test.js
+++ b/__tests__/PaginationBoxView-test.js
@@ -5,9 +5,9 @@ jest.dontMock('./../react_components/PaginationBoxView');
 jest.dontMock('./../react_components/PageView');
 jest.dontMock('./../react_components/BreakView');
 
-const PaginationBoxView = require('./../react_components/PaginationBoxView').default;
-const PageView = require('./../react_components/PageView').default;
-const BreakView = require('./../react_components/BreakView').default;
+import PaginationBoxView from './../react_components/PaginationBoxView';
+import PageView from './../react_components/PageView';
+import BreakView from './../react_components/BreakView';
 
 import ReactTestUtils from 'react-dom/test-utils';
 
@@ -125,6 +125,30 @@ describe('PaginationBoxView', () => {
       );
 
       expect(onPageChange).toHaveBeenCalled();
+    });
+  });
+
+  describe('prop disabledClassName', () => {
+    it('defaults to disable when no provided', function() {
+      const pagination = ReactTestUtils.renderIntoDocument(
+        <PaginationBoxView
+          initialPage={0}
+          pageCount={1}
+        />
+      );
+      expect(ReactDOM.findDOMNode(pagination).querySelector("li:first-child").className).toBe("previous disabled");
+      expect(ReactDOM.findDOMNode(pagination).querySelector("li:last-child").className).toBe("next disabled");
+    });
+    it('use the prop when provided', function() {
+      const pagination = ReactTestUtils.renderIntoDocument(
+        <PaginationBoxView
+          initialPage={0}
+          pageCount={1}
+          disabledClassName="custom disabled class"
+        />
+      );
+      expect(ReactDOM.findDOMNode(pagination).querySelector("li:first-child").className).toBe("previous custom disabled class");
+      expect(ReactDOM.findDOMNode(pagination).querySelector("li:last-child").className).toBe("next custom disabled class");
     });
   });
 });

--- a/dist/PaginationBoxView.js
+++ b/dist/PaginationBoxView.js
@@ -219,8 +219,8 @@ var PaginationBoxView = function (_Component) {
 
 
       var disabled = disabledClassName;
-      var previousClasses = previousClassName + (selected === 0 ? ' disabled' : '');
-      var nextClasses = nextClassName + (selected === pageCount - 1 ? ' disabled' : '');
+      var previousClasses = previousClassName + (selected === 0 ? ' ' + disabledClassName : '');
+      var nextClasses = nextClassName + (selected === pageCount - 1 ? ' ' + disabledClassName : '');
 
       return _react2.default.createElement(
         'ul',

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -225,8 +225,8 @@ export default class PaginationBoxView extends Component {
     const { selected } = this.state;
 
     let disabled = disabledClassName;
-    const previousClasses = previousClassName + (selected === 0 ? ' disabled' : '');
-    const nextClasses = nextClassName + (selected === pageCount - 1 ? ' disabled' : '');
+    const previousClasses = previousClassName + (selected === 0 ? ` ${disabledClassName}` : '');
+    const nextClasses = nextClassName + (selected === pageCount - 1 ? ` ${disabledClassName}` : '');
 
     return (
       <ul className={containerClassName}>


### PR DESCRIPTION
Same as #205 

Fix for #204 

Maybe just to use for the test cases that also check the default `disabledClassName`