### PR TITLE
Add role="button" to pagination anchor tags

### DIFF
--- a/dist/PageView.js
+++ b/dist/PageView.js
@@ -34,6 +34,7 @@ var PageView = function PageView(props) {
     _react2.default.createElement(
       'a',
       { onClick: onClick,
+        role: 'button',
         className: linkClassName,
         href: href,
         tabIndex: '0',

--- a/dist/PaginationBoxView.js
+++ b/dist/PaginationBoxView.js
@@ -233,6 +233,7 @@ var PaginationBoxView = function (_Component) {
               className: previousLinkClassName,
               href: this.hrefBuilder(selected - 1),
               tabIndex: '0',
+              role: 'button',
               onKeyPress: this.handlePreviousPage },
             previousLabel
           )
@@ -247,6 +248,7 @@ var PaginationBoxView = function (_Component) {
               className: nextLinkClassName,
               href: this.hrefBuilder(selected + 1),
               tabIndex: '0',
+              role: 'button',
               onKeyPress: this.handleNextPage },
             nextLabel
           )

--- a/react_components/PageView.js
+++ b/react_components/PageView.js
@@ -24,6 +24,7 @@ const PageView = (props) => {
   return (
       <li className={cssClassName}>
           <a onClick={onClick}
+             role="button"
              className={linkClassName}
              href={href}
              tabIndex="0"

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -234,6 +234,7 @@ export default class PaginationBoxView extends Component {
              className={previousLinkClassName}
              href={this.hrefBuilder(selected - 1)}
              tabIndex="0"
+             role="button"
              onKeyPress={this.handlePreviousPage}>
             {previousLabel}
           </a>
@@ -246,6 +247,7 @@ export default class PaginationBoxView extends Component {
              className={nextLinkClassName}
              href={this.hrefBuilder(selected + 1)}
              tabIndex="0"
+             role="button"
              onKeyPress={this.handleNextPage}>
             {nextLabel}
           </a>


### PR DESCRIPTION
Since it is possible to have pagination anchors without an href, screen readers will interpret this as a non-interactive element, and then be potentially confused about the tabindex="0" attribute: we end up with an element which is implicitly not interactive (no href) but explicitly added to the document's tab stops.

I added a role="button" to let screen readers know explicitly that those anchors are intended to be interactive elements.