### PR TITLE
Page break is now clickable and hrefBuilder returns '#' by default

### DIFF
--- a/dist/BreakView.js
+++ b/dist/BreakView.js
@@ -11,13 +11,27 @@ var _react2 = _interopRequireDefault(_react);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var BreakView = function BreakView(props) {
+  var cssClassName = props.breakClassName || 'break';
+  var linkClassName = props.breakLinkClassName;
+  var onClick = props.onClick;
+  var href = props.href;
+  var ariaLabel = 'Page ' + props.page + (props.extraAriaContext ? ' ' + props.extraAriaContext : '');
   var label = props.breakLabel;
-  var className = props.breakClassName || 'break';
 
   return _react2.default.createElement(
     'li',
-    { className: className },
-    label
+    { className: cssClassName },
+    _react2.default.createElement(
+      'a',
+      { onClick: onClick,
+        role: 'button',
+        className: linkClassName,
+        href: href,
+        tabIndex: '0',
+        'aria-label': ariaLabel,
+        onKeyPress: onClick },
+      label
+    )
   );
 };
 

--- a/dist/PaginationBoxView.js
+++ b/dist/PaginationBoxView.js
@@ -179,6 +179,8 @@ var PaginationBoxView = function (_Component) {
       if (hrefBuilder && pageIndex !== this.state.selected && pageIndex >= 0 && pageIndex < pageCount) {
         return hrefBuilder(pageIndex + 1);
       }
+
+      return '#';
     }
   }, {
     key: 'getPageElement',

--- a/dist/PaginationBoxView.js
+++ b/dist/PaginationBoxView.js
@@ -82,7 +82,9 @@ var PaginationBoxView = function (_Component) {
           pageCount = _this$props.pageCount,
           marginPagesDisplayed = _this$props.marginPagesDisplayed,
           breakLabel = _this$props.breakLabel,
-          breakClassName = _this$props.breakClassName;
+          breakClassName = _this$props.breakClassName,
+          breakLinkClassName = _this$props.breakLinkClassName,
+          extraAriaContext = _this$props.extraAriaContext;
       var selected = _this.state.selected;
 
 
@@ -125,16 +127,25 @@ var PaginationBoxView = function (_Component) {
             continue;
           }
 
-          if (_index >= selected - leftSide && _index <= selected + rightSide) {
+          var withinLeft = _index <= selected + rightSide;
+          var withinRight = _index >= selected - leftSide;
+
+          if (withinLeft && withinRight) {
             items.push(createPageView(_index));
             continue;
           }
 
           if (breakLabel && items[items.length - 1] !== breakView) {
+            var breakIdx = withinLeft ? Math.floor(selected - leftSide) : _index;
             breakView = _react2.default.createElement(_BreakView2.default, {
               key: _index,
+              onClick: _this.handlePageSelected.bind(null, breakIdx),
               breakLabel: breakLabel,
-              breakClassName: breakClassName
+              breakClassName: breakClassName,
+              breakLinkClassName: breakLinkClassName,
+              extraAriaContext: extraAriaContext,
+              href: _this.hrefBuilder(_index),
+              page: page
             });
             items.push(breakView);
           }
@@ -283,7 +294,8 @@ PaginationBoxView.propTypes = {
   previousLinkClassName: _propTypes2.default.string,
   nextLinkClassName: _propTypes2.default.string,
   disabledClassName: _propTypes2.default.string,
-  breakClassName: _propTypes2.default.string
+  breakClassName: _propTypes2.default.string,
+  breakLinkClassName: _propTypes2.default.string
 };
 PaginationBoxView.defaultProps = {
   pageCount: 10,

--- a/react_components/BreakView.js
+++ b/react_components/BreakView.js
@@ -3,12 +3,25 @@
 import React from 'react';
 
 const BreakView = (props) => {
+  let cssClassName = props.breakClassName || 'break';
+  const linkClassName = props.breakLinkClassName;
+  const onClick = props.onClick;
+  const href = props.href;
+  let ariaLabel = 'Page ' + props.page +
+    (props.extraAriaContext ? ' ' + props.extraAriaContext : '');
   const label = props.breakLabel;
-  const className = props.breakClassName || 'break';
 
   return (
-    <li className={className}>
-      {label}
+    <li className={cssClassName}>
+      <a onClick={onClick}
+          role="button"
+          className={linkClassName}
+          href={href}
+          tabIndex="0"
+          aria-label={ariaLabel}
+          onKeyPress={onClick}>
+        {label}
+      </a>
     </li>
   );
 }

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -107,6 +107,8 @@ export default class PaginationBoxView extends Component {
     ) {
       return hrefBuilder(pageIndex + 1);
     }
+
+    return '#';
   }
 
   callCallback = (selectedItem) => {

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -28,7 +28,8 @@ export default class PaginationBoxView extends Component {
     previousLinkClassName : PropTypes.string,
     nextLinkClassName     : PropTypes.string,
     disabledClassName     : PropTypes.string,
-    breakClassName        : PropTypes.string
+    breakClassName        : PropTypes.string,
+    breakLinkClassName    : PropTypes.string,
   };
 
   static defaultProps = {
@@ -146,7 +147,9 @@ export default class PaginationBoxView extends Component {
       pageCount,
       marginPagesDisplayed,
       breakLabel,
-      breakClassName
+      breakClassName,
+      breakLinkClassName,
+      extraAriaContext,
     } = this.props;
 
     const { selected } = this.state;
@@ -190,17 +193,26 @@ export default class PaginationBoxView extends Component {
           continue;
         }
 
-        if ((index >= selected - leftSide) && (index <= selected + rightSide)) {
+        let withinLeft = (index <= selected + rightSide);
+        let withinRight = (index >= selected - leftSide);
+        
+        if (withinLeft && withinRight) {
           items.push(createPageView(index));
           continue;
         }
 
         if (breakLabel && items[items.length - 1] !== breakView) {
+          let breakIdx = withinLeft ? Math.floor(selected - leftSide) : index;
           breakView = (
             <BreakView
               key={index}
+              onClick={this.handlePageSelected.bind(null, breakIdx)}
               breakLabel={breakLabel}
               breakClassName={breakClassName}
+              breakLinkClassName={breakLinkClassName}
+              extraAriaContext={extraAriaContext}
+              href={this.hrefBuilder(index)}
+              page={page}
             />
           );
           items.push(breakView);


### PR DESCRIPTION
Clicking the page break between sets of pages now triggers a page change event to the page at the location of the break. This is less visually disruptive, and makes more sense from a user standpoint.

hrefBuilder also returns '#' by default. This removes the necessity of having tabindex="0" on every link element, however I left those in-place for reverse compatibility. This does not affect link-based navigation.