### PR TITLE
remove params that are not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Open your browser and go to [http://localhost:3000/](http://localhost:3000/)
 
 | Name                     | Type       | Description                                                                                  |
 | ------------------------ | ---------- | -------------------------------------------------------------------------------------------- |
-| `pageCount`              | `Number`   | **Required.** The total number of pages.                                                     |
+| `pageCount`              | `Number`   | The total number of pages.                                                     |
 | `pageRangeDisplayed`     | `Number`   | The range of pages displayed.                                                  |
 | `marginPagesDisplayed`   | `Number`   | The number of pages to display for margins.                                    |
 | `previousLabel`          | `Node`     | Label for the `previous` button.                                                             |

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Open your browser and go to [http://localhost:3000/](http://localhost:3000/)
 | Name                     | Type       | Description                                                                                  |
 | ------------------------ | ---------- | -------------------------------------------------------------------------------------------- |
 | `pageCount`              | `Number`   | **Required.** The total number of pages.                                                     |
-| `pageRangeDisplayed`     | `Number`   | **Required.** The range of pages displayed.                                                  |
-| `marginPagesDisplayed`   | `Number`   | **Required.** The number of pages to display for margins.                                    |
+| `pageRangeDisplayed`     | `Number`   | The range of pages displayed.                                                  |
+| `marginPagesDisplayed`   | `Number`   | The number of pages to display for margins.                                    |
 | `previousLabel`          | `Node`     | Label for the `previous` button.                                                             |
 | `nextLabel`              | `Node`     | Label for the `next` button.                                                                 |
 | `breakLabel`             | `Node`     | Label for ellipsis.                                                                          |

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -8,8 +8,8 @@ import BreakView from './BreakView';
 export default class PaginationBoxView extends Component {
   static propTypes = {
     pageCount: PropTypes.number.isRequired,
-    pageRangeDisplayed: PropTypes.number.isRequired,
-    marginPagesDisplayed: PropTypes.number.isRequired,
+    pageRangeDisplayed: PropTypes.number,
+    marginPagesDisplayed: PropTypes.number,
     previousLabel: PropTypes.node,
     nextLabel: PropTypes.node,
     breakLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -7,7 +7,7 @@ import BreakView from './BreakView';
 
 export default class PaginationBoxView extends Component {
   static propTypes = {
-    pageCount: PropTypes.number.isRequired,
+    pageCount: PropTypes.number,
     pageRangeDisplayed: PropTypes.number,
     marginPagesDisplayed: PropTypes.number,
     previousLabel: PropTypes.node,


### PR DESCRIPTION
They have a default - they are not required

```typescript
  static defaultProps = {
    pageCount: 10,
    pageRangeDisplayed: 2,
    marginPagesDisplayed: 3,
    activeClassName: 'selected',
    previousClassName: 'previous',
    nextClassName: 'next',
    previousLabel: 'Previous',
    nextLabel: 'Next',
    breakLabel: '...',
    disabledClassName: 'disabled',
    disableInitialCallback: false,
  };
```