### PR TITLE
Applying eslint rules and enforcing for the future

### DIFF
--- a/__tests__/PaginationBoxView-test.js
+++ b/__tests__/PaginationBoxView-test.js
@@ -37,7 +37,7 @@ describe('Test rendering', () => {
     expect(pages.length).toEqual(9);
   });
 
-  it('test rendering only active page item', function() {
+  it('test rendering only active page item', function () {
     const pagination = ReactTestUtils.renderIntoDocument(
       <PaginationBoxView
         initialPage={0}
@@ -154,7 +154,9 @@ describe('Test clicks', () => {
 
 describe('Test custom event listener', () => {
   it('test custom listener on previous and next buttons', () => {
-    const pagination = ReactTestUtils.renderIntoDocument(<PaginationBoxView eventListener="onMouseOver" />);
+    const pagination = ReactTestUtils.renderIntoDocument(
+      <PaginationBoxView eventListener="onMouseOver" />
+    );
 
     let elmts = ReactTestUtils.scryRenderedDOMComponentsWithTag(
       pagination,
@@ -177,7 +179,9 @@ describe('Test custom event listener', () => {
   });
 
   it('test custom listener on a page item', () => {
-    const pagination = ReactTestUtils.renderIntoDocument(<PaginationBoxView eventListener="onMouseOver" />);
+    const pagination = ReactTestUtils.renderIntoDocument(
+      <PaginationBoxView eventListener="onMouseOver" />
+    );
 
     ReactTestUtils.findRenderedComponentWithType(pagination, PaginationBoxView);
 
@@ -249,7 +253,7 @@ describe('Test pagination behaviour', () => {
     const elements = ReactDOM.findDOMNode(pagination).querySelectorAll(
       'li:not(.previous):not(.next)'
     );
-    elements.forEach(element => {
+    elements.forEach((element) => {
       if (breakElementReached === false && element.className !== 'break') {
         leftElements.push(element);
       } else if (
@@ -295,7 +299,7 @@ describe('Test pagination behaviour', () => {
     const elements = ReactDOM.findDOMNode(pagination).querySelectorAll(
       'li:not(.previous):not(.next)'
     );
-    elements.forEach(element => {
+    elements.forEach((element) => {
       if (breakElementReached === false && element.className !== 'break') {
         leftElements.push(element);
       } else if (
@@ -343,7 +347,7 @@ describe('Test pagination behaviour', () => {
     const elements = ReactDOM.findDOMNode(pagination).querySelectorAll(
       'li:not(.previous):not(.next)'
     );
-    elements.forEach(element => {
+    elements.forEach((element) => {
       if (
         leftBreakElementReached === false &&
         rightBreakElementReached === false &&
@@ -404,7 +408,7 @@ describe('Test pagination behaviour', () => {
     const elements = ReactDOM.findDOMNode(pagination).querySelectorAll(
       'li:not(.previous):not(.next)'
     );
-    elements.forEach(element => {
+    elements.forEach((element) => {
       if (breakElementReached === false && element.className !== 'break') {
         leftElements.push(element);
       } else if (
@@ -450,7 +454,7 @@ describe('Test pagination behaviour', () => {
     const elements = ReactDOM.findDOMNode(pagination).querySelectorAll(
       'li:not(.previous):not(.next)'
     );
-    elements.forEach(element => {
+    elements.forEach((element) => {
       if (breakElementReached === false && element.className !== 'break') {
         leftElements.push(element);
       } else if (
@@ -471,7 +475,7 @@ describe('Test pagination behaviour', () => {
     expect(breakElements.length).toBe(1);
   });
 
-  it('should use ariaLabelBuilder for rendering aria-labels if ariaLabelBuilder is specified', function() {
+  it('should use ariaLabelBuilder for rendering aria-labels if ariaLabelBuilder is specified', function () {
     const linkedPagination = ReactTestUtils.renderIntoDocument(
       <PaginationBoxView
         initialPage={1}
@@ -500,7 +504,7 @@ describe('Test pagination behaviour', () => {
     ).toBe('Current page');
   });
 
-  it('test ariaLabelBuilder works with extraAriaContext', function() {
+  it('test ariaLabelBuilder works with extraAriaContext', function () {
     const linkedPagination = ReactTestUtils.renderIntoDocument(
       <PaginationBoxView
         initialPage={1}
@@ -688,7 +692,7 @@ describe('Test default props', () => {
   });
 
   describe('default disabledClassName', () => {
-    it('should use the default disabledClassName', function() {
+    it('should use the default disabledClassName', function () {
       const pagination = ReactTestUtils.renderIntoDocument(
         <PaginationBoxView initialPage={0} pageCount={1} />
       );
@@ -704,7 +708,7 @@ describe('Test default props', () => {
   });
 
   describe('default hrefBuilder', () => {
-    it('should not render href attributes on page items if hrefBuilder is not defined', function() {
+    it('should not render href attributes on page items if hrefBuilder is not defined', function () {
       const linkedPagination = ReactTestUtils.renderIntoDocument(
         <PaginationBoxView />
       );
@@ -802,7 +806,7 @@ describe('Test custom props', () => {
       ).toBe('...');
     });
 
-    it('should use the breakClassName prop when defined', function() {
+    it('should use the breakClassName prop when defined', function () {
       const pagination = ReactTestUtils.renderIntoDocument(
         <PaginationBoxView breakClassName={'break-me'} />
       );
@@ -811,7 +815,7 @@ describe('Test custom props', () => {
       ).not.toBe(null);
     });
 
-    it('should use the breakLinkClassName prop when defined', function() {
+    it('should use the breakLinkClassName prop when defined', function () {
       const pagination = ReactTestUtils.renderIntoDocument(
         <PaginationBoxView breakLinkClassName={'break-link'} />
       );
@@ -1083,29 +1087,42 @@ describe('Test custom props', () => {
   });
 
   describe('prevRel/nextRel', () => {
-    it('should render default rel if they are not specified', function() {
+    it('should render default rel if they are not specified', function () {
       const linkedPagination = ReactTestUtils.renderIntoDocument(
         <PaginationBoxView pageCount={3} />
       );
 
-      expect(ReactDOM.findDOMNode(linkedPagination).querySelector('li:last-child a')
-        .getAttribute('rel')).toBe('next');
-      expect(ReactDOM.findDOMNode(linkedPagination).querySelector('li:first-child a')
-        .getAttribute('rel')).toBe('prev');
+      expect(
+        ReactDOM.findDOMNode(linkedPagination)
+          .querySelector('li:last-child a')
+          .getAttribute('rel')
+      ).toBe('next');
+      expect(
+        ReactDOM.findDOMNode(linkedPagination)
+          .querySelector('li:first-child a')
+          .getAttribute('rel')
+      ).toBe('prev');
     });
 
-    it('should render custom rel if they are defined', function() {
+    it('should render custom rel if they are defined', function () {
       const linkedPagination = ReactTestUtils.renderIntoDocument(
-        <PaginationBoxView pageCount={3}
-                           nextRel={'nofollow noreferrer'}
-                           prevRel={'nofollow noreferrer'}
+        <PaginationBoxView
+          pageCount={3}
+          nextRel={'nofollow noreferrer'}
+          prevRel={'nofollow noreferrer'}
         />
       );
 
-      expect(ReactDOM.findDOMNode(linkedPagination).querySelector('li:last-child a')
-        .getAttribute('rel')).toBe('nofollow noreferrer');
-      expect(ReactDOM.findDOMNode(linkedPagination).querySelector('li:first-child a')
-        .getAttribute('rel')).toBe('nofollow noreferrer');
+      expect(
+        ReactDOM.findDOMNode(linkedPagination)
+          .querySelector('li:last-child a')
+          .getAttribute('rel')
+      ).toBe('nofollow noreferrer');
+      expect(
+        ReactDOM.findDOMNode(linkedPagination)
+          .querySelector('li:first-child a')
+          .getAttribute('rel')
+      ).toBe('nofollow noreferrer');
     });
   });
 
@@ -1130,11 +1147,11 @@ describe('Test custom props', () => {
   });
 
   describe('hrefBuilder', () => {
-    it('should use the hrefBuilder prop when defined', function() {
+    it('should use the hrefBuilder prop when defined', function () {
       const pagination = ReactTestUtils.renderIntoDocument(
         <PaginationBoxView
           initialPage={1}
-          hrefBuilder={page => '/page/' + page}
+          hrefBuilder={(page) => '/page/' + page}
         />
       );
 
@@ -1230,28 +1247,41 @@ describe('Test custom props', () => {
     ).toBe('true');
   });
 
-  it('should render default aria labels if they are not specified', function() {
+  it('should render default aria labels if they are not specified', function () {
     const linkedPagination = ReactTestUtils.renderIntoDocument(
       <PaginationBoxView pageCount={3} />
     );
 
-    expect(ReactDOM.findDOMNode(linkedPagination).querySelector('li:last-child a')
-      .getAttribute('aria-label')).toBe('Next page');
-    expect(ReactDOM.findDOMNode(linkedPagination).querySelector('li:first-child a')
-      .getAttribute('aria-label')).toBe('Previous page');
+    expect(
+      ReactDOM.findDOMNode(linkedPagination)
+        .querySelector('li:last-child a')
+        .getAttribute('aria-label')
+    ).toBe('Next page');
+    expect(
+      ReactDOM.findDOMNode(linkedPagination)
+        .querySelector('li:first-child a')
+        .getAttribute('aria-label')
+    ).toBe('Previous page');
   });
 
-  it('should render custom aria labels if they are defined', function() {
+  it('should render custom aria labels if they are defined', function () {
     const linkedPagination = ReactTestUtils.renderIntoDocument(
-      <PaginationBoxView pageCount={3}
-                          nextAriaLabel={'Go to the next page'}
-                          previousAriaLabel={'Go to the previous page'}
+      <PaginationBoxView
+        pageCount={3}
+        nextAriaLabel={'Go to the next page'}
+        previousAriaLabel={'Go to the previous page'}
       />
     );
 
-    expect(ReactDOM.findDOMNode(linkedPagination).querySelector('li:last-child a')
-      .getAttribute('aria-label')).toBe('Go to the next page');
-    expect(ReactDOM.findDOMNode(linkedPagination).querySelector('li:first-child a')
-      .getAttribute('aria-label')).toBe('Go to the previous page');
+    expect(
+      ReactDOM.findDOMNode(linkedPagination)
+        .querySelector('li:last-child a')
+        .getAttribute('aria-label')
+    ).toBe('Go to the next page');
+    expect(
+      ReactDOM.findDOMNode(linkedPagination)
+        .querySelector('li:first-child a')
+        .getAttribute('aria-label')
+    ).toBe('Go to the previous page');
   });
 });

--- a/__tests__/PaginationBoxView-test.js
+++ b/__tests__/PaginationBoxView-test.js
@@ -866,18 +866,19 @@ describe('Test custom props', () => {
 
     it('should update forcePage and hence selected page when forcePage value is changed', () => {
       const node = document.createElement('div');
-      const pagination1 = ReactDOM.render(
-        <PaginationBoxView forcePage={2} />,
-        node
+      ReactDOM.render(<PaginationBoxView forcePage={2} />, node);
+      const pagination = React.createRef();
+      ReactDOM.render(
+        <PaginationBoxView ref={pagination} forcePage={3} />,
+        node,
+        () => {
+          expect(
+            ReactDOM.findDOMNode(pagination.current).querySelector(
+              '.selected a'
+            ).textContent
+          ).toBe('3');
+        }
       );
-      const pagination2 = ReactDOM.render(
-        <PaginationBoxView forcePage={3} />,
-        node
-      );
-      expect(
-        ReactDOM.findDOMNode(pagination2).querySelector('.selected a')
-          .textContent
-      ).toBe('4');
     });
   });
 

--- a/__tests__/PaginationBoxView-test.js
+++ b/__tests__/PaginationBoxView-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-find-dom-node */
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
-  "plugins": ["@babel/plugin-proposal-class-properties"],
+  presets: ['@babel/preset-env', '@babel/preset-react'],
+  plugins: ['@babel/plugin-proposal-class-properties'],
 };

--- a/demo/server.js
+++ b/demo/server.js
@@ -35,7 +35,7 @@ function getPaginatedItems(items, offset) {
   return items.slice(offset, offset + PER_PAGE);
 }
 
-app.get('/comments', function(req, res) {
+app.get('/comments', function (req, res) {
   var items = JSON.parse(fs.readFileSync(DATA));
   var offset = req.query.offset ? parseInt(req.query.offset, 10) : 0;
   var nextOffset = offset + PER_PAGE;
@@ -57,6 +57,6 @@ app.get('/comments', function(req, res) {
   return res.json(json);
 });
 
-app.listen(NODE_PORT, function() {
+app.listen(NODE_PORT, function () {
   console.log('Demo server running on %s mode on port %d', NODE_ENV, NODE_PORT); // eslint-disable-line
 });

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -1,5 +1,3 @@
-/* global __dirname */
-
 const path = require('path');
 
 const dir_demo_js = path.resolve(__dirname, 'js');

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  "verbose": true
-}
+  verbose: true,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2133,6 +2133,12 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
     "@types/prettier": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
@@ -3618,6 +3624,12 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -3739,6 +3751,39 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+      "dev": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        }
+      }
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -5082,6 +5127,15 @@
         "locate-path": "^2.0.0"
       }
     },
+    "find-versions": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+      "dev": true,
+      "requires": {
+        "semver-regex": "^3.1.2"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -5581,6 +5635,133 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
+    },
+    "husky": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.7.tgz",
+      "integrity": "sha512-0fQlcCDq/xypoyYSJvEuzbDPHFf8ZF9IXKJxlrnvxABTSzK1VPT2RKYQKrcgJ+YD39swgoB6sbzywUqFxUiqjw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "compare-versions": "^3.6.0",
+        "cosmiconfig": "^7.0.0",
+        "find-versions": "^4.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^5.0.0",
+        "please-upgrade-node": "^3.2.0",
+        "slash": "^3.0.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -8693,6 +8874,12 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "dev": true
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -9025,6 +9212,15 @@
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         }
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "posix-character-classes": {
@@ -9834,6 +10030,18 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "semver-regex": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
+      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
       "dev": true
     },
     "send": {
@@ -11602,6 +11810,12 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "dev": true
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -11765,6 +11979,12 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "dev": true
+    },
     "yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -11888,6 +12108,12 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.5",
     "express": "^4.17.1",
+    "husky": "^4.3.7",
     "jest-cli": "^26.6.3",
     "jquery": "^3.5.1",
     "prettier": "^2.0.5",
@@ -56,6 +57,13 @@
     "test": "jest",
     "build": "webpack --config webpack.config.js --mode=production",
     "demo": "webpack --config demo/webpack.config.js --mode=development && node demo/data.js && node demo/server.js",
-    "start": "npm run demo"
+    "start": "npm run demo",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run lint"
+    }
   }
 }

--- a/react_components/BreakView.js
+++ b/react_components/BreakView.js
@@ -4,7 +4,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const BreakView = (props) => {
-  const { breakLabel, breakClassName, breakLinkClassName, breakHandler, getEventListener } = props;
+  const {
+    breakLabel,
+    breakClassName,
+    breakLinkClassName,
+    breakHandler,
+    getEventListener,
+  } = props;
   const className = breakClassName || 'break';
 
   return (

--- a/react_components/PageView.js
+++ b/react_components/PageView.js
@@ -13,21 +13,18 @@ const PageView = (props) => {
     getEventListener,
     pageSelectedHandler,
     href,
-    extraAriaContext
+    extraAriaContext,
   } = props;
 
   let ariaLabel =
     props.ariaLabel ||
-    'Page ' +
-      page +
-      (extraAriaContext ? ' ' + extraAriaContext : '');
+    'Page ' + page + (extraAriaContext ? ' ' + extraAriaContext : '');
   let ariaCurrent = null;
 
   if (selected) {
     ariaCurrent = 'page';
 
-    ariaLabel =
-      props.ariaLabel || 'Page ' + page + ' is your current page';
+    ariaLabel = props.ariaLabel || 'Page ' + page + ' is your current page';
 
     if (typeof pageClassName !== 'undefined') {
       pageClassName = pageClassName + ' ' + activeClassName;

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -136,7 +136,7 @@ export default class PaginationBoxView extends Component {
     return {
       [eventListener]: handlerFunction,
     };
-  }
+  };
 
   getForwardJump() {
     const { selected } = this.state;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,3 @@
-/* global __dirname */
-
 const path = require('path');
 
 const dir_js = path.resolve(__dirname, 'react_components');
@@ -55,4 +53,4 @@ module.exports = (env, argv) => {
     config.output.path = dir_dist;
   }
   return config;
-}
+};


### PR DESCRIPTION
I noticed in my previous PR that there are several things that break the described eslint rules. This PR fixes the outstanding eslint issues and adds a library called husky to enforce the lint rules in future commits.

* Almost all of the rules were auto-fixable (now the command `npm run lint:fix`) 
* had to disable one rule in the tests because theres not other option
* Had one test that needed major changes because React recommends not using the return value for react.render anymore. I left a comment in the source