### PR TITLE
Remove react-hot-loader from production build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,6 @@ const dir_dist = path.resolve(__dirname, 'dist');
 const dir_node_modules = path.resolve(__dirname, 'node_modules');
 
 const config = {
-  target: 'node',
   entry: path.resolve(dir_js, 'index.js'),
   output: {
     path: dir_build,
@@ -52,7 +51,9 @@ const config = {
 
 module.exports = (env, argv) => {
   if (argv.mode === 'production') {
+    config.mode = 'production',
     config.output.path = dir_dist;
+    config.module.rules = config.module.rules.filter(rule => rule.use !== 'react-hot-loader/webpack');
   }
   return config;
 }


### PR DESCRIPTION
So i'm unable to re-create a small test case for this, but working on upgrading plugins.jenkins.io to gatsby 3, I was getting an unknown error. I tracked it down to importing the chunk that included react-paginate.

So reading up on building umd libraries in webpack didn't give me any useful directions, so on a whim I decided to filter out the hot loader, and low and behold the app finally loaded.

I don't see any reason why hot loader should be included in the bundle, so PR to remove it. I personally think you should add it in non production mode, rather than removing it from production build.