### PR TITLE
Add option to define rel property for page number anchor tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ You can also check this **[CodePen demo](https://codepen.io/monsieurv/pen/yLoMxY
 | `ariaLabelBuilder`       | `Function` | The method is called to generate the `aria-label` attribute value on each page link                                                                                    |
 | `eventListener`          | `String`   | The event to listen onto before changing the selected page. Default is: `onClick`.                                                                                     |
 | `renderOnZeroPageCount`  | `Function` | A render fonction called when `pageCount` is zero. Let the Previous / Next buttons displayed by default (`undefined`). Display nothing when `null` is provided.        |
+| `prevPageRel`            | `String`   | The `rel` property on `a` tag for just before the selected page. Default value `prev`.                                                                                 |
+|`selectedPageRel`         | `String`   | The `rel` propery on `a` tag for the selected page. Default value `canonical`.                                                                                         |
+| `nextPageRel`            | `String`   | The `rel` property on `a` tag for just after the selected page. Default value `next`.                                                                                  |
 
 ## Demo
 

--- a/__tests__/PaginationBoxView-test.js
+++ b/__tests__/PaginationBoxView-test.js
@@ -1474,4 +1474,198 @@ describe('Test custom props', () => {
       ).toBe('Item 1');
     });
   });
+  describe('prevPageRel/nextPageRel/selectedPageRel', () => {
+    it('should render default rel if not defined', function () {
+      const pagination = ReactTestUtils.renderIntoDocument(
+        <PaginationBoxView pageCount={4} />
+      );
+
+      const activeItem =
+        ReactDOM.findDOMNode(pagination).querySelector('li:nth-child(3) a');
+      ReactTestUtils.Simulate.click(activeItem);
+
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-child(3) a')
+          .getAttribute('rel')
+      ).toBe('canonical');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-child(2) a')
+          .getAttribute('rel')
+      ).toBe('prev');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-child(4) a')
+          .getAttribute('rel')
+      ).toBe('next');
+    });
+    it('should render custom rel if defined', function () {
+      const pagination = ReactTestUtils.renderIntoDocument(
+        <PaginationBoxView
+          pageCount={4}
+          prevPageRel="custom-prev-rel"
+          nextPageRel="custom-next-rel"
+          selectedPageRel="custom-selected-rel"
+        />
+      );
+
+      const activeItem =
+        ReactDOM.findDOMNode(pagination).querySelector('li:nth-child(3) a');
+      ReactTestUtils.Simulate.click(activeItem);
+
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-child(3) a')
+          .getAttribute('rel')
+      ).toBe('custom-selected-rel');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-child(2) a')
+          .getAttribute('rel')
+      ).toBe('custom-prev-rel');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-child(4) a')
+          .getAttribute('rel')
+      ).toBe('custom-next-rel');
+    });
+    it('should not render prevPageRel and nextPageRel if pageCount is 1', function () {
+      const pagination = ReactTestUtils.renderIntoDocument(
+        <PaginationBoxView pageCount={1} />
+      );
+
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:first-child a')
+          .getAttribute('aria-label')
+      ).toBe('Previous page');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-Child(2) a')
+          .getAttribute('rel')
+      ).toBe('canonical');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('.selected a')
+          .getAttribute('rel')
+      ).toBe('canonical');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-last-Child(2) a')
+          .getAttribute('rel')
+      ).toBe('canonical');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:last-child a')
+          .getAttribute('aria-label')
+      ).toBe('Next page');
+    });
+    it('should not render prevPageRel if selected page is first', function () {
+      const pagination = ReactTestUtils.renderIntoDocument(
+        <PaginationBoxView pageCount={4} />
+      );
+
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-Child(1) a')
+          .getAttribute('aria-label')
+      ).toBe('Previous page');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-Child(2) a')
+          .getAttribute('rel')
+      ).toBe('canonical');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-Child(3) a')
+          .getAttribute('rel')
+      ).toBe('next');
+    });
+    it('should not render nextPageRel if selected page is last', function () {
+      const pagination = ReactTestUtils.renderIntoDocument(
+        <PaginationBoxView pageCount={4} />
+      );
+
+      const activeItem = ReactDOM.findDOMNode(pagination).querySelector(
+        'li:nth-last-child(2) a'
+      );
+      ReactTestUtils.Simulate.click(activeItem);
+
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-last-Child(1) a')
+          .getAttribute('aria-label')
+      ).toBe('Next page');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-last-Child(2) a')
+          .getAttribute('rel')
+      ).toBe('canonical');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-last-Child(3) a')
+          .getAttribute('rel')
+      ).toBe('prev');
+    });
+    it('should not render prevPageRel if the break page is present just before the selected page', function () {
+      const pagination = ReactTestUtils.renderIntoDocument(
+        <PaginationBoxView
+          pageCount={20}
+          marginPagesDisplayed={2}
+          pageRangeDisplayed={0}
+        />
+      );
+
+      const activeItem =
+        ReactDOM.findDOMNode(pagination).querySelector('li:nth-child(3) a');
+      ReactTestUtils.Simulate.click(activeItem);
+
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-Child(2) a')
+          .getAttribute('rel')
+      ).toBe('prev');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-Child(3) a')
+          .getAttribute('rel')
+      ).toBe('canonical');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-Child(4)')
+          .getAttribute('class')
+      ).toBe('break');
+    });
+    it('should not render nextPageRel if the break page is present just after the selected page', function () {
+      const pagination = ReactTestUtils.renderIntoDocument(
+        <PaginationBoxView
+          pageCount={20}
+          marginPagesDisplayed={2}
+          pageRangeDisplayed={0}
+        />
+      );
+
+      const activeItem = ReactDOM.findDOMNode(pagination).querySelector(
+        'li:nth-last-child(3) a'
+      );
+
+      ReactTestUtils.Simulate.click(activeItem);
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-last-Child(2) a')
+          .getAttribute('rel')
+      ).toBe('next');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-last-Child(3) a')
+          .getAttribute('rel')
+      ).toBe('canonical');
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-last-Child(4)')
+          .getAttribute('class')
+      ).toBe('break');
+    });
+  });
 });

--- a/__tests__/PaginationBoxView-test.js
+++ b/__tests__/PaginationBoxView-test.js
@@ -1608,7 +1608,7 @@ describe('Test custom props', () => {
           .getAttribute('rel')
       ).toBe('prev');
     });
-    it('should not render prevPageRel if the break page is present just before the selected page', function () {
+    it('should not render nextPageRel if the break page is present just after the selected page', function () {
       const pagination = ReactTestUtils.renderIntoDocument(
         <PaginationBoxView
           pageCount={20}
@@ -1637,7 +1637,7 @@ describe('Test custom props', () => {
           .getAttribute('class')
       ).toBe('break');
     });
-    it('should not render nextPageRel if the break page is present just after the selected page', function () {
+    it('should not render prevPageRel if the break page is present just before the selected page', function () {
       const pagination = ReactTestUtils.renderIntoDocument(
         <PaginationBoxView
           pageCount={20}

--- a/__tests__/PaginationBoxView-test.js
+++ b/__tests__/PaginationBoxView-test.js
@@ -1530,6 +1530,41 @@ describe('Test custom props', () => {
           .getAttribute('rel')
       ).toBe('custom-next-rel');
     });
+    it('should not render rel if prePageRel, selectedPageRel and nextPageRel are null', function () {
+      const pagination = ReactTestUtils.renderIntoDocument(
+        <PaginationBoxView
+          pageCount={4}
+          prevPageRel={null}
+          nextPageRel={null}
+          selectedPageRel={null}
+        />
+      );
+
+      const activeItem =
+        ReactDOM.findDOMNode(pagination).querySelector('li:nth-Child(3) a');
+      ReactTestUtils.Simulate.click(activeItem);
+
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-child(2) a')
+          .getAttribute('rel')
+      ).toBe(null);
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-child(3) a')
+          .getAttribute('rel')
+      ).toBe(null);
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('.selected a')
+          .getAttribute('rel')
+      ).toBe(null);
+      expect(
+        ReactDOM.findDOMNode(pagination)
+          .querySelector('li:nth-child(4) a')
+          .getAttribute('rel')
+      ).toBe(null);
+    });
     it('should not render prevPageRel and nextPageRel if pageCount is 1', function () {
       const pagination = ReactTestUtils.renderIntoDocument(
         <PaginationBoxView pageCount={1} />

--- a/react_components/PageView.js
+++ b/react_components/PageView.js
@@ -15,6 +15,7 @@ const PageView = (props) => {
     href,
     extraAriaContext,
     pageLabelBuilder,
+    rel,
   } = props;
 
   let ariaLabel =
@@ -45,6 +46,7 @@ const PageView = (props) => {
   return (
     <li className={pageClassName}>
       <a
+        rel={rel}
         role={!href ? 'button' : undefined}
         className={pageLinkClassName}
         href={href}
@@ -73,6 +75,7 @@ PageView.propTypes = {
   page: PropTypes.number.isRequired,
   getEventListener: PropTypes.func.isRequired,
   pageLabelBuilder: PropTypes.func.isRequired,
+  rel: PropTypes.string,
 };
 
 export default PageView;

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -245,7 +245,7 @@ export default class PaginationBoxView extends Component {
       this.props.onPageActive({ selected: selectedItem });
     }
   };
-  handlePageRel = (index) => {
+  getElementPageRel = (index) => {
     const { selected } = this.state;
     const { nextPageRel, prevPageRel, selectedPageRel } = this.props;
 
@@ -275,7 +275,7 @@ export default class PaginationBoxView extends Component {
         key={index}
         pageSelectedHandler={this.handlePageSelected.bind(null, index)}
         selected={selected === index}
-        rel={this.handlePageRel(index)}
+        rel={this.getElementPageRel(index)}
         pageClassName={pageClassName}
         pageLinkClassName={pageLinkClassName}
         activeClassName={activeClassName}

--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -12,9 +12,11 @@ export default class PaginationBoxView extends Component {
     marginPagesDisplayed: PropTypes.number.isRequired,
     previousLabel: PropTypes.node,
     previousAriaLabel: PropTypes.string,
+    prevPageRel: PropTypes.string,
     prevRel: PropTypes.string,
     nextLabel: PropTypes.node,
     nextAriaLabel: PropTypes.string,
+    nextPageRel: PropTypes.string,
     nextRel: PropTypes.string,
     breakLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     hrefBuilder: PropTypes.func,
@@ -41,6 +43,7 @@ export default class PaginationBoxView extends Component {
     ariaLabelBuilder: PropTypes.func,
     eventListener: PropTypes.string,
     renderOnZeroPageCount: PropTypes.func,
+    selectedPageRel: PropTypes.string,
   };
 
   static defaultProps = {
@@ -51,10 +54,12 @@ export default class PaginationBoxView extends Component {
     previousLabel: 'Previous',
     previousClassName: 'previous',
     previousAriaLabel: 'Previous page',
+    prevPageRel: 'prev',
     prevRel: 'prev',
     nextLabel: 'Next',
     nextClassName: 'next',
     nextAriaLabel: 'Next page',
+    nextPageRel: 'next',
     nextRel: 'next',
     breakLabel: '...',
     disabledClassName: 'disabled',
@@ -62,6 +67,7 @@ export default class PaginationBoxView extends Component {
     pageLabelBuilder: (page) => page,
     eventListener: 'onClick',
     renderOnZeroPageCount: undefined,
+    selectedPageRel: 'canonical',
   };
 
   constructor(props) {
@@ -239,6 +245,19 @@ export default class PaginationBoxView extends Component {
       this.props.onPageActive({ selected: selectedItem });
     }
   };
+  handlePageRel = (index) => {
+    const { selected } = this.state;
+    const { nextPageRel, prevPageRel, selectedPageRel } = this.props;
+
+    if (selected - 1 === index) {
+      return prevPageRel;
+    } else if (selected === index) {
+      return selectedPageRel;
+    } else if (selected + 1 === index) {
+      return nextPageRel;
+    }
+    return undefined;
+  };
 
   getPageElement(index) {
     const { selected } = this.state;
@@ -256,6 +275,7 @@ export default class PaginationBoxView extends Component {
         key={index}
         pageSelectedHandler={this.handlePageSelected.bind(null, index)}
         selected={selected === index}
+        rel={this.handlePageRel(index)}
         pageClassName={pageClassName}
         pageLinkClassName={pageLinkClassName}
         activeClassName={activeClassName}


### PR DESCRIPTION
The following changes add the 'rel' property to the page number anchor tag.

By default, it assigns the 'rel' property of 'canonical' to the selected page. The page just before the selected page and page just after the selected page is assigned the 'rel' property of value 'prev' and  'next'  respectively. The rest of the pages are not assigned 'rel' property.

This change will be an improvement for SEO.
It solves #386.

