### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,8 @@
 __tests__
+build
 demo
 docs
+*.log
 .editorconfig
 .eslintignore
 .eslintrc.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+__tests__
+demo
+docs
+.editorconfig
+.eslintignore
+.eslintrc.json
+.prettierignore
+.prettierrc
+.travis.yml
+babel.config.js
+jest.config.js
+Makefile
+TODO.md
+webpack.config.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## >= 9.0.0 (WIP)
 
 - Removed support for depecrated `extraAriaContext` (please use `ariaLabelBuilder` instead)
+- Excluded unnecessary files from package (see: https://github.com/AdeleD/react-paginate/issues/410)
 
 ## >= 8.1.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-paginate",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "A ReactJS component that creates a pagination.",
   "main": "./dist/react-paginate.js",
   "repository": {


### PR DESCRIPTION
With .npmignore file, npm excludes these files from package. Published package size will be smaller. See also https://docs.npmjs.com/cli/v8/using-npm/developers#keeping-files-out-of-your-package .