### PR TITLE
Update demo.js comment typo

### DIFF
--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -9,7 +9,7 @@ import $ from 'jquery';
 // thanks to styled-components.
 // Use inner class names to style the controls.
 const MyPaginate = styled(ReactPaginate).attrs({
-  // You can redifine classes here, if you want.
+  // You can redefine classes here, if you want.
   activeClassName: 'active', // default to "disabled"
 })`
   margin-bottom: 2rem;

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -10,7 +10,7 @@ import $ from 'jquery';
 // Use inner class names to style the controls.
 const MyPaginate = styled(ReactPaginate).attrs({
   // You can redefine classes here, if you want.
-  activeClassName: 'active', // default to "disabled"
+  activeClassName: 'active', // default to "selected"
 })`
   margin-bottom: 2rem;
   display: flex;


### PR DESCRIPTION
- The word is written as "redifine" which does not exist. Redefine should be.
- indicate correctly the default class name when active.