### PR TITLE
removed useEffect and pageCount, currentItems states from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ function PaginatedItems({ itemsPerPage }) {
   // following the API or data you're working with.
   const [itemOffset, setItemOffset] = useState(0);
 
-  // Fetch items from another resources.
+  // Simulate fetching items from another resources.
+  // (This could be items from props; or items loaded in a local state
+  // from an API endpoint with useEffect and useState)
   const endOffset = itemOffset + itemsPerPage;
   console.log(`Loading items from ${itemOffset} to ${endOffset}`);
   const currentItems = items.slice(itemOffset, endOffset);

--- a/README.md
+++ b/README.md
@@ -46,20 +46,15 @@ function Items({ currentItems }) {
 }
 
 function PaginatedItems({ itemsPerPage }) {
-  // We start with an empty list of items.
-  const [currentItems, setCurrentItems] = useState(null);
-  const [pageCount, setPageCount] = useState(0);
   // Here we use item offsets; we could also use page offsets
   // following the API or data you're working with.
   const [itemOffset, setItemOffset] = useState(0);
 
-  useEffect(() => {
-    // Fetch items from another resources.
-    const endOffset = itemOffset + itemsPerPage;
-    console.log(`Loading items from ${itemOffset} to ${endOffset}`);
-    setCurrentItems(items.slice(itemOffset, endOffset));
-    setPageCount(Math.ceil(items.length / itemsPerPage));
-  }, [itemOffset, itemsPerPage]);
+  // Fetch items from another resources.
+  const endOffset = itemOffset + itemsPerPage;
+  console.log(`Loading items from ${itemOffset} to ${endOffset}`);
+  const currentItems = items.slice(itemOffset, endOffset);
+  const pageCount = Math.ceil(items.length / itemsPerPage);
 
   // Invoke when user click to request another page.
   const handlePageClick = (event) => {


### PR DESCRIPTION
## Changes:
1. removed pageCount, currentItems states and useEffect from the docs

## Testing:
https://codesandbox.io/s/react-paginate-useeffect-02gfrr?file=/src/App.js:597-868

## Reference:
[Issue #441](https://github.com/AdeleD/react-paginate/issues/441)