### PR TITLE
Fix renderOnZeroPageCount props type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -223,7 +223,7 @@ export interface ReactPaginateProps {
    * A render function called when `pageCount` is zero. Let the Previous / Next buttons displayed by default (`undefined`).
    * Display nothing when `null` is provided.
    */
-  renderOnZeroPageCount?: (props: ReactPaginateProps) => void | null;
+  renderOnZeroPageCount?: ((props: ReactPaginateProps) => void) | null;
 
   /**
    * The `rel` propery on the `a` tag for the selected page.


### PR DESCRIPTION
Per the documentation you can pass either a function, undefined or null. The way the type is set the `null` applies to the return of the function and not to the prop itself.