### PR TITLE
Fixed #488

### DIFF
--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -72,7 +72,7 @@ export default class PaginationBoxView extends Component {
     breakAriaLabels: { forward: 'Jump forward', backward: 'Jump backward' },
     disabledClassName: 'disabled',
     disableInitialCallback: false,
-    pageLabelBuilder: (page) => page,
+    pageLabelBuilder: (page) => page.toLocaleString(),
     eventListener: 'onClick',
     renderOnZeroPageCount: undefined,
     selectedPageRel: 'canonical',


### PR DESCRIPTION
This PR fixes #488 by adding a toLocaleString() function on the PaginationBoxView.js Line 75.

The screenshot for the same is attached for reference:
![ss2](https://github.com/AdeleD/react-paginate/assets/121241830/4dc577a2-3efc-4c11-81d2-6c016faf8efb)
![ss1](https://github.com/AdeleD/react-paginate/assets/121241830/a2876c61-a7e5-47c6-a41b-d90c6a959985)
