### PR TITLE
Fix remove aria-role navigation of 'ul' element

### DIFF
--- a/react_components/PaginationBoxView.js
+++ b/react_components/PaginationBoxView.js
@@ -574,7 +574,6 @@ export default class PaginationBoxView extends Component {
     return (
       <ul
         className={className || containerClassName}
-        role="navigation"
         aria-label="Pagination"
       >
         <li className={previousClasses}>


### PR DESCRIPTION
I removed role='navigation' in 'ul'

According to W3C standard. You can check this also Chrome Develop tool - Lighthouse.

https://w3c.github.io/html-aria/#el-ul

Roles: **group, listbox, menu, menubar, none, presentation, radiogroup, tablist, toolbar or tree**. (list is also allowed, but NOT RECOMMENDED.)



